### PR TITLE
Create RuboCop action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,9 +195,9 @@ jobs:
       - restore_cache:
           key: checkout-{{ .Branch }}-{{ .Revision }}
       - run: bundle install
-      - run:
-          name: Run RuboCop
-          command: bundle exec rubocop --parallel
+      # - run:
+      #     name: Run RuboCop
+      #     command: bundle exec rubocop --parallel
 
   ruby-2-4:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,18 +187,6 @@ jobs:
             COVERAGE=true bundle exec rake
             ./tmp/cc-test-reporter after-build --exit-code $?
 
-  rubocop:
-    executor:
-      name: default
-      tag: "2.4"
-    steps:
-      - restore_cache:
-          key: checkout-{{ .Branch }}-{{ .Revision }}
-      - run: bundle install
-      # - run:
-      #     name: Run RuboCop
-      #     command: bundle exec rubocop --parallel
-
   ruby-2-4:
     executor:
       name: default
@@ -265,25 +253,18 @@ workflows:
       - code-climate:
           requires:
             - checkout
-      - rubocop:
-          requires:
-            - checkout
       - ruby-2-4:
           requires:
             - code-climate
-            - rubocop
       - ruby-2-5:
           requires:
             - code-climate
-            - rubocop
       - ruby-2-6:
           requires:
             - code-climate
-            - rubocop
       - ruby-head:
           requires:
             - code-climate
-            - rubocop
 
   nightly:
     triggers:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,22 @@
+name: Lint Ruby
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Ruby 2.7
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.7.x
+    - name: Lint Ruby code with RuboCop
+      run: |
+        gem install bundler
+        bundle install --gemfile gemfiles/rubocop.gemfile --jobs 4 --retry 3
+        bundle exec --gemfile gemfiles/rubocop.gemfile rubocop

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.lock
 *.log
 .DS_Store
+/*.gem

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
 
 Layout/LineLength:
   Max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.4
 
 Layout/LineLength:
   Max: 120

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'rubocop', '~> 0.79.0'
+gem 'rubocop-performance', '~> 1.5', '>= 1.5.2'
+gem 'rubocop-rspec', '~> 1.37', '>= 1.37.1'

--- a/mailgun-tracking.gemspec
+++ b/mailgun-tracking.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Artem Chubchenko']
   spec.email         = ['artem.chubchenko@gmail.com']
 
-  spec.summary       = 'Integration with Mailgun Webhooks'
+  spec.summary       = 'Mailgun webhook integration for Rack/RoR application'
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/chubchenko/mailgun-tracking'
   spec.license       = 'MIT'
@@ -33,8 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '>= 0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.7'
-  spec.add_development_dependency 'rubocop', '~> 0.79.0'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.5'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.36'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
 end


### PR DESCRIPTION
Migrate Ruby Lint (RuboCop) from `CircleCI` to GitHub action.