### PR TITLE
Bugfix/build stabilization

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -27,6 +27,13 @@ jobs:
           "gemfiles/hanami_head.gemfile",
           "gemfiles/sinatra.gemfile"
         ]
+        exclude:
+          - gemfile: "gemfiles/rails_head.gemfile"
+            ruby: 2.5
+          - gemfile: "gemfiles/rails_head.gemfile"
+            ruby: 2.6
+          - gemfile: "gemfiles/rails_head.gemfile"
+            ruby: jruby
     steps:
       - uses: actions/checkout@master
       - name: Set up Ruby

--- a/lib/mailgun/tracking/version.rb
+++ b/lib/mailgun/tracking/version.rb
@@ -34,7 +34,7 @@ module Mailgun
       #
       # @return [Hash]
       def to_h
-        ::Hash[KEYS.zip(to_a)]
+        KEYS.zip(to_a).to_h
       end
 
       # Return an array representation of version.


### PR DESCRIPTION
### What is the purpose of this pull request?

Stabilize GA build

### What changes did you make? (overview)

- Exclude Ruby < 2.7 for RoR master
- Use `ary.to_h` instead of `Hash[ary]`